### PR TITLE
Revert evaluation template to correct formatting

### DIFF
--- a/evaluation_template.md
+++ b/evaluation_template.md
@@ -14,28 +14,12 @@
 1. What is the project's license?
 In most repositories there will be a file named LICENSE or something similar in
 the root level of the repository. This is the one to examine. There may be
-different licenses on specific files, but the project will have a main license.
-<br>
+different licenses on specific files, but the project will have a main license.  <br>
 
 ---
 
 ### Code Base
 
-
-1. What is the primary programming language in the project?
-<br>
-
-1. What is the development environment? For example, is it Gnu C++ on Linux?
-Are there instructions for how to download, build, and install?
-<br>
-
-1. Does the project depend on external additional software modules such as
-database,  graphics, web development, or other libraries?
-<br>
-
-1. Is the code easy to understand? Browse some source code files and make
-a judgment based on your random sample.
-<br>
 
 1. What is the primary programming language in the project? <br>
 
@@ -47,7 +31,6 @@ database,  graphics, web development, or other libraries? <br>
 
 1. Is the code easy to understand? Browse some source code files and make
 a judgment based on your random sample.  <br>
-
 
 1. Is this a big project? If you can, find out about how many lines of code
 are in it, perhaps on [OpenHub](https://www.openhub.net/).  <br>
@@ -68,31 +51,6 @@ are in it, perhaps on [OpenHub](https://www.openhub.net/).  <br>
 ### Activity Level
 
 
-
-1. How many commits have been made in the past week?
-<br>
-
-1. When was the most recent commit?
-<br>
-
-1. How many issues are currently open?
-<br>
-
-1. How long do issues stay open?
-Take the five most recently closed issues and look at when each was first reported.
-Compute the number of days that each was open and take the average.
-<br>
-
-1. Is there active discussion on the issues?
-Read the conversations from some open and some closed issues.
-<br>
-
-1. Are issues tagged as easy, hard, for beginners, etc.?
-<br>
-
-1. How many issues were closed in the past six months?
-<br>
-
 1. How many commits have been made in the past week? <br>
 
 1. When was the most recent commit? <br>
@@ -110,70 +68,29 @@ Read the conversations from some open and some closed issues.  <br>
 
 1. How many issues were closed in the past six months? <br>
 
-1. Is there information about how many people are maintaining the project?
-<br>
+1. Is there information about how many people are maintaining the project? <br>
 
-1. How many contributors has the project had in the past six months?
-<br>
+1. How many contributors has the project had in the past six months? <br>
 
-
-1. How many open pull requests are there?
-<br>
-
-1. Is there information about how many people are maintaining the project? 
-<br>
-
-1. How many contributors has the project had in the past six months? 
-<br>
-
-1. How many open pull requests are there? 
-<br>
-
+1. How many open pull requests are there? <br>
 
 1. Do pull requests remain un-answered for a long time?
 Look at the closed pull requests to see how long they stayed open.
 Take the five most recently closed ones and look at when each was first reported.
-Compute the number of days that each was open and take the average.
-<br>
-
-1. Is there active discussion on the pull requests?
-Use the same method as you did for the issues.
-<br>
-
-1. How many pull requests were opened within the past six months?
-<br>
-
 Compute the number of days that each was open and take the average.  <br>
 
 1. Is there active discussion on the pull requests?
-Use the same method as you did for the issues.  
-<br>
+Use the same method as you did for the issues.  <br>
 
+1. How many pull requests were opened within the past six months? <br>
 
-1. How many pull requests were opened within the past six months? 
-<br>
-
-1. When was the last  pull request  merged? 
-<br>
+1. When was the last  pull request  merged? <br>
 
 ---
 
 ### Welcomeness and Community
 
 1. Is there a CONTRIBUTING document? If so, how easy to read and understand is it?
-Look through it and see if it is clear and thorough.
-<br>
-
-1. Is there a CODE OF CONDUCT document? Does it have consequences for acts that
-violte it?
-<br>
-
-1. Do the maintainers respond helpfully to questions in issues?
-Are responses generally constructive?
-Read the issue conversations.
-<br>
-
-1. Are people friendly in the issues, discussion forum, and chat?
 Look through it and see if it is clear and thorough.  <br>
 
 1. Is there a CODE OF CONDUCT document? Does it have consequences for acts that
@@ -184,7 +101,6 @@ Are responses generally constructive?
 Read the issue conversations.  <br>
 
 1. Are people friendly in the issues, discussion forum, and chat? <br> 
-
 
 1. Do maintainers thank people for their contributions? <br>
 


### PR DESCRIPTION
#36 Accidentally overwrote the evaluation_template, breaking the line numbering. I reverted back to the last commit for the file so the template is correct for posterity.